### PR TITLE
[11.0][FIX] l10n_es_account_bank_statement_import_n43: Change encoding for compatibility with BBVA files

### DIFF
--- a/l10n_es_account_bank_statement_import_n43/wizards/account_bank_statement_import_n43.py
+++ b/l10n_es_account_bank_statement_import_n43/wizards/account_bank_statement_import_n43.py
@@ -185,7 +185,7 @@ class AccountBankStatementImport(models.TransientModel):
         return st_data['groups']
 
     def _check_n43(self, data_file):
-        data_file = data_file.decode('iso-8859-1')
+        data_file = data_file.decode('utf-8-sig')
         try:
             n43 = self._parse(data_file)
         except exceptions.ValidationError:  # pragma: no cover


### PR DESCRIPTION
La importación de extracto bancario mediante fichero N43 no funciona con el BBVA.

Los ficheros de BBVA están codificados en UTF-8 pero incluyen el BOM, los de otras entidades (ABANCA y TargoBank) están en UTF-8 sin BOM.
La codificación anterior leía los ficheros sin BOM pero fallaba en el caso de BBVA porque lo incluye.

Con la nueva codificación se leen correctamente todos los tipos de fichero.

#1056
